### PR TITLE
增加对Laravel Filesystem API中的temporaryUrl接口的支持

### DIFF
--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -573,6 +573,33 @@ class AliOssAdapter extends AbstractAdapter
         if (!$this->has($path)) throw new FileNotFoundException($path.' not found');
         return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->isCname ? ( $this->cdnDomain == '' ? $this->endPoint : $this->cdnDomain ) : $this->bucket . '.' . $this->endPoint ) . '/' . ltrim($path, '/');
     }
+    
+    
+    /**
+     * @param $path
+     * @param $expire
+     * @param $options
+     * @return string
+     * @throws FileNotFoundException
+     * @throws OssException
+     */
+    public function getTemporaryUrl($path, $expire, $options) {
+        if (!$this->has($path))
+            throw new FileNotFoundException($path.' not found');
+        $method = OssClient::OSS_HTTP_GET;
+        if (Arr::has($options, OssClient::OSS_METHOD)) {
+            $method = $options['method'];
+        }
+        return $this->getClient()
+            ->signUrl(
+                $this->getBucket(),
+                $path,
+                now()->diffInSeconds($expire),
+                $method,
+                $options
+            );
+    }
+    
 
     /**
      * The the ACL visibility.


### PR DESCRIPTION
针对 #3 的改动

1. 两边的接口中的第二个时间参数的含义不同：
在Laravel中为到期时间，传入的是到期的一个carbon对象，参见例子中的
```
$url = Storage::temporaryUrl(
    'file.jpg', now()->addMinutes(5)
);
```
在aliyun oss中的含义是从现在开始的秒数。
因此函数中做了一个跟当前时间的diff。

2. 另外aliyun oss中把method单独提出来作为了一个参数，这里从option中取了出来进行赋值。