### PR TITLE
添加安全令牌配置 以支持 临时配置上传功能

### DIFF
--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -40,6 +40,7 @@ class AliOssServiceProvider extends ServiceProvider
             $bucket    = $config['bucket'];
             $ssl       = empty($config['ssl']) ? false : $config['ssl'];
             $isCname   = empty($config['isCName']) ? false : $config['isCName'];
+            $securityToken = empty($config['securityToken']) ? '' : $config['securityToken'];
             $debug     = empty($config['debug']) ? false : $config['debug'];
 
             $endPoint  = $config['endpoint']; // 默认作为外部节点
@@ -47,7 +48,7 @@ class AliOssServiceProvider extends ServiceProvider
 
             if($debug) Log::debug('OSS config:', $config);
 
-            $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname);
+            $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname, $securityToken);
             $adapter = new AliOssAdapter($client, $bucket, $endPoint, $ssl, $isCname, $debug, $cdnDomain);
 
             //Log::debug($client);


### PR DESCRIPTION
本人项目遇到了临时配置上传功能，使用的该包发现不支持配置该选项，故pr。
以下是我的动态调用方式
```
config([
    'filesystems.disks.oss.access_id' => $imageConfig['data']['AccessKeyId'],
    'filesystems.disks.oss.access_key' => $imageConfig['data']['AccessKeySecret'],
    'filesystems.disks.oss.securityToken' => $imageConfig['data']['SecurityToken'],
]);
$storage = Storage::disk('oss');
```