### PR TITLE
去除不必要(且会导致配置丢失)的对 $options 包装

### DIFF
--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -660,7 +660,7 @@ class AliOssAdapter extends AbstractAdapter
             $options = array_merge($options, $this->getOptionsFromConfig($config));
         }
 
-        return array(OssClient::OSS_HEADERS => $options);
+        return $options;
     }
 
     /**


### PR DESCRIPTION
fix #13 

在上传文件时按函数参数名，感觉可以传入 `$options`，例如：
```php
$oss = Storage::disk('oss');
$oss->put($file_path, $content, ['ContentType' => 'image/jpeg']);
```
就可以避免 Laravel 自己来猜测 ContentType 而导致文件大的话就会爆内存的问题，

__至少我是这么以为的__

__但是。。。__

此 `$options` 会在真正使用前，被 [`AliOssAdapter::getOptions`](https://github.com/summergeorge/Aliyun-oss-storage/blame/master/src/AliOssAdapter.php#L655-L664) 方法调用；
经过一些处理，此方法会返回：
```php
return array(OssClient::OSS_HEADERS => $options);
```

至此，所有的初始传入的 `$options`  都会藏到真正调用 oss 的参数中的 `headers` 里。

然鹅，在[下一步的代码里](https://github.com/summergeorge/Aliyun-oss-storage/blame/master/src/AliOssAdapter.php#L147-L165)，代码开始检查是否 `$options` 有对一些参数赋值。

但在上一步，之前外部传来的参数就被折叠到 headers 里去了，所以不会有任何作用，所以代码一定还会调用 `Util::guessMimeType` 来猜测文件类型，所以要爆内存还是得爆；

以及，在之后的调用阿里云SDK自己的 OssClient 时，client 也都是直接从 `$options` 中获取参数的，[例如这里的 Content-Type](https://github.com/aliyun/aliyun-oss-php-sdk/blame/master/src/OSS/OssClient.php#L3270-L3291)

所以，此PR将不必要的 wrap 去除

（因为感觉有些奇怪之前没必要非得包一层而且代码在五年前就是这样的了而且阿里云的代码似乎也五年没改了，这是一开始就有的问题还是因为阿里云的SDK之前有改动造成的问题呢？所以写了比较长的 PR Comment）